### PR TITLE
Feat: add support for specifying model binding keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,17 @@ FilamentLinkPickerPlugin::make()
     ->translateLabels();
 ```
 
+You can also set the column name, for to set the value while resolving the model route binding options.
+```php
+Route::get('/event/{event:slug}', 'show')->name('show')->filamentLinkPicker(
+        label: 'Single Event',
+        group: 'Details Page',
+        parameterModelKeys: [
+            'event' => 'slug',
+        ]
+    );
+```
+
 The following items can be translated:
 
 - label: The label of the route defined in the `filamentLinkPicker()` method.

--- a/src/FilamentLinkPickerServiceProvider.php
+++ b/src/FilamentLinkPickerServiceProvider.php
@@ -47,7 +47,7 @@ class FilamentLinkPickerServiceProvider extends PackageServiceProvider
 
         Route::macro(
             'filamentLinkPicker',
-            function (?string $label = null, ?string $group = null, bool $isLocalized = false, array $parameterLabels = [], array $parameterOptions = []) {
+            function (?string $label = null, ?string $group = null, bool $isLocalized = false, array $parameterLabels = [], array $parameterOptions = [], array $parameterModelKeys = []) {
                 /** @var Route $route */
                 $route = $this;
 
@@ -57,7 +57,8 @@ class FilamentLinkPickerServiceProvider extends PackageServiceProvider
                     'group' => $group,
                     'isLocalized' => $isLocalized,
                     'parameterLabels' => $parameterLabels,
-                    'parameterOptions' => $parameterOptions
+                    'parameterOptions' => $parameterOptions,
+                    'parameterModelKeys' => $parameterModelKeys
                 ];
             }
         );

--- a/src/Services/LinkPicker.php
+++ b/src/Services/LinkPicker.php
@@ -149,7 +149,8 @@ class LinkPicker
                     $data['group'] ?? null,
                     $data['isLocalized'] ?? false,
                     $data['parameterLabels'] ?? [],
-                    $data['parameterOptions'] ?? []
+                    $data['parameterOptions'] ?? [],
+                    $data['parameterModelKeys']??[]
                 ));
             });
     }


### PR DESCRIPTION
Normally while resolving option for binding its using model's getKey() method.

But there are many case when i dont want to override the getKey() method of a modal. 

This pr allows to specify the route binding key while generation options.

Fixing the issue of #1 